### PR TITLE
Escape the jq params for ZSH Compatibility

### DIFF
--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -7,7 +7,7 @@ To obtain a default installation without Prometheus alerting interlock
 or Slack notifications:
 
 ```console
-latest=$(curl -s https://api.github.com/repos/kubereboot/kured/releases | jq -r .[0].tag_name)
+latest=$(curl -s https://api.github.com/repos/kubereboot/kured/releases | jq -r '.[0].tag_name')
 kubectl apply -f "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-dockerhub.yaml"
 ```
 


### PR DESCRIPTION
When using zsh, the square brackets get evaluated and break the install steps. Adding the single quotes safely escapes the jq params.

Signed-off-by: Ivan Smirnov <isgsmirnov@gmail.com>