### PR TITLE
add bluesky confirmation

### DIFF
--- a/static/.well-known/atproto-did
+++ b/static/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:hn7k32coclx5vve2xagb4rox


### PR DESCRIPTION
this will the kured account allow to move from `kubereboot` to `kured.dev` as a recognised domain