### PR TITLE
Update content to match 1.20 release manifest names

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -61,12 +61,12 @@ In order to make kured run on these nodes as well we will need to edit the daemo
 You can get a full deployment file by running the followig command:
 
 ```bash
-# while writing latest is 1.14.0
+# while writing latest is 1.20.0
 latest=$(curl -s https://api.github.com/repos/kubereboot/kured/releases | jq -r '.[0].tag_name')
-wget "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-dockerhub.yaml"
+wget "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-combined.yaml"
 ```
 
-In the `kured-1.14.0-dockerhub.yaml` the daemonset has the following tolerations:
+In the `kured-1.20.0-combined.yaml` the daemonset has the following tolerations:
 
 ```yaml
 tolerations:
@@ -86,7 +86,7 @@ tolerations:
     operator: Exists
 ```
 
-after applying the `kured-1.14.0-dockerhub.yaml` file you can check the number of pods with:
+after applying the `kured-1.20.0-combined.yaml` file you can check the number of pods with:
 
 ```bash
 kubectl -n kube-system get daemonsets/kured

--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -10,7 +10,7 @@ or Slack notifications:
 
 ```console
 latest=$(curl -s https://api.github.com/repos/kubereboot/kured/releases | jq -r '.[0].tag_name')
-kubectl apply -f "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-dockerhub.yaml"
+kubectl apply -f "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-combined.yaml"
 ```
 
 If you want to customise the installation, download the manifest and


### PR DESCRIPTION
Starting from release 1.20, we moved the file to "combined" instead of "dockerhub". This PR fixes the filename to get rid of that debt.